### PR TITLE
Set filetype to iec instead of st/il

### DIFF
--- a/ftdetect/iec.vim
+++ b/ftdetect/iec.vim
@@ -1,4 +1,4 @@
-autocmd BufRead,BufNewFile *.il setf iec
-autocmd BufRead,BufNewFile *.IL setf iec
-autocmd BufRead,BufNewFile *.st setf iec
-autocmd BufRead,BufNewFile *.ST setf iec
+autocmd BufRead,BufNewFile *.il setl ft=iec
+autocmd BufRead,BufNewFile *.IL setl ft=iec
+autocmd BufRead,BufNewFile *.st setl ft=iec
+autocmd BufRead,BufNewFile *.ST setl ft=iec

--- a/ftdetect/iec.vim
+++ b/ftdetect/iec.vim
@@ -1,4 +1,4 @@
-autocmd BufRead,BufNewFile *.il setf il
-autocmd BufRead,BufNewFile *.IL setf il
-autocmd BufRead,BufNewFile *.st setf st
-autocmd BufRead,BufNewFile *.ST setf st
+autocmd BufRead,BufNewFile *.il setf iec
+autocmd BufRead,BufNewFile *.IL setf iec
+autocmd BufRead,BufNewFile *.st setf iec
+autocmd BufRead,BufNewFile *.ST setf iec


### PR DESCRIPTION
Hi, thanks a lot for this plugin.

I have a problem with the included ftdetect.  It seems the filetype of the plugin was changed to `iec` everywhere but the ftdetect autocmds still set filetype to `st`/`il`.  Unless I am missing something, this PR fixes this.

Additionally, it seems my vim runtime already contains a line like

```vim
au BufNewFile,BufRead *.st			setf st
```

which means the `setf` from `ftdetect/iec.vim` will not apply.  To force the `iec` filetype, I switched this to `setl ft=` instead.

Let me know what you think.