### PR TITLE
Correctly set undo_ftplugin variable

### DIFF
--- a/ftplugin/iec.vim
+++ b/ftplugin/iec.vim
@@ -20,3 +20,9 @@ setlocal formatoptions+=cro
 setlocal tabstop=2
 setlocal softtabstop=2
 setlocal shiftwidth=2
+
+if exists('b:undo_ftplugin')
+  let b:undo_ftplugin .= "|setl fo< fdm< com< cms< ts< sts< sw<"
+else
+  let b:undo_ftplugin = "setl fo< fdm< com< cms< ts< sts< sw<"
+endif


### PR DESCRIPTION
Hi, I've got a second PR as well:  This allows "undoing" all filetype settings correctly when switching to another filetype.

See `:help undo_ftplugin` for more details.