### PR TITLE
syntax: Allow // comments

### DIFF
--- a/ftplugin/iec.vim
+++ b/ftplugin/iec.vim
@@ -11,7 +11,7 @@ setlocal formatoptions-=t
 setlocal foldmethod=indent
 
 " Define comments string
-setlocal comments=
+setlocal comments=s1:(*,mb:*,ex:*),://
 setlocal commentstring=(*%s*)
 
 " Enable automatic comment insertion

--- a/syntax/iec.vim
+++ b/syntax/iec.vim
@@ -120,6 +120,7 @@ syn keyword STStatement OVERLAP REF_TO NULL
 
 " {{{ Comments
 syn region IECComment start="(\*" end="\*)"
+syn region IECComment start="//" end="$"
 " }}}
 
 " {{{ Highlighting


### PR DESCRIPTION
A lot of ST programming environments allow using // to start a comment until the end of the line.  Properly highlight such comments.